### PR TITLE
[그럴듯한 서비스 만들기] 1단계 - 서비스 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@ npm run dev
 
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
-- 대역 : 
+- 대역
+
+  |Purpose|Criteria|Name|Subnet ID|IPv4 CIDR|
+      |---|---|---|---|---|
+  |외부망|Public|catsbi-a|subnet-06260fce1eea456b3|192.168.0.0/26|
+  |데이터베이스|Public|catsbi-b|subnet-0d4e8ae2fc3fb01ca|192.168.0.64/26|
+  |내부망|Private|catsbi-c|subnet-01b22938e34ae5676|192.168.0.128/26|
+  |관리용|Private|catsbi-d|subnet-024e6e23e1c1c8463|192.168.0.160/26|  
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
+- URL : http://infra.catsbi-subway.kro.kr:8080/
 
 3. 베스천 서버에 접속을 위한 pem키는 [구글드라이브](https://drive.google.com/drive/folders/1dZiCUwNeH1LMglp8dyTqqsL1b2yBnzd1?usp=sharing)에 업로드해주세요
 


### PR DESCRIPTION
# 1단계 미션 - 망 구성하기
## 망 구성
- [x] VPC 생성
    - CIDR은 C class(x.x.x.x/24)로 생성. 이 때, 다른 사람과 겹치지 않게 생성
        - catsbi-vpc / CIDR: 192.168.0.0/24
- [x] Subnet 생성
    - [x] 외부망으로 사용할 Subnet : 64개씩 2개 (AZ를 다르게 구성)
        - catsbi-a(ap-northeast-2a)
        - catsbi-b(ap-northeast-2b)
    - [x] 내부망으로 사용할 Subnet : 32개씩 1개
        - catsbi-c(ap-northeast-2c)
    - [x] 관리용으로 사용할 Subnet : 32개씩 1개
        - catsbi-d(ap-northeast-2c)
- [x] Internet Gateway 연결
    - catsbi-igw(igw-01e1e5d2c0b713403)
- [x] Route Table 생성
    - catsbi-public-rt(rtb-04b4ee7967b31e473)
    - catsbi-internal-rt(rtb-0c3e5b233d2e5c444)
    - catsbi-bastion-rt(rtb-0e121b9c9d8ea1c86)
- [x] Security Group 설정
    - catsbi-public-sg(sg-06f02149ea677d4ce)
    - catsbi-internal-sg(sg-015cc7e3ab2753437)
    - catsbi-bastion-sg(sg-01e3d5401169f4084)
- **외부망**
    - [x] 전체 대역 : 8080 포트 오픈
    - [x] 관리망 : 22번 포트 오픈
- **내부망**
    - [x] 외부망 : 3306 포트 오픈
    - [x] 관리망 : 22번 포트 오픈
- **관리망**
    - [x] 자신의 공인 IP : 22번 포트 오픈
- **서버 생성**
    - [x] 외부망에 웹 서비스용도의 EC2 생성
    - [x] 내부망에 데이터베이스용도의 EC2 생성
    - [x] 관리망에 베스쳔 서버용도의 EC2 생성
    - [x] 베스쳔 서버에 Session Timeout 600s 설정
    - [x] 베스쳔 서버에 Command 감사로그 설정

### 질의사항
- Bastion 서버를 만들어서 그안에서 웹서버(외부망)으로 설정된 EC2에 접속이 가능한 상황인데, putty나 terminus에서 매번 Bastion 서버에 ssh로 접속후 그 안에서 다시 ssh로 웹서버에 접속을 해야하는 것인가요?

- shell prompt 변경은 root 권한을 얻었을때도 적용되게 해야하는게 맞나요? 

### 1단계 미션 소감
네트워크는 학부수업때도 크게 열심히 듣지 않았던지라 만만치가 않았던 것 같습니다.
최근 부랴부랴 네트워크 책을 사서 보면서 키워드라도 귀에 익어서 겨우 듣는데 더 노력해야 할 것 같습니다. 
