### PR TITLE
[그럴듯한 인프라 만들기 Step2] 리뷰 요청드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ npm run dev
 ### 2단계 - 배포하기
 1. TLS가 적용된 URL을 알려주세요
 
-- URL : 
+- URL : [https://subway.javajigi.p-e.kr](https://subway.javajigi.p-e.kr)

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	runtimeOnly 'com.h2database:h2'
+
+	implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.25'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.25'
+	runtimeOnly("org.flywaydb:flyway-core:5.2.0")
 }
 
 test {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,7 +1,4 @@
-spring.datasource.url=jdbc:h2:file:~/h2/localsub
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver
+spring.datasource.url= jdbc:mysql://localhost/subway?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username= root
+spring.datasource.password= masterpw

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:file:~/h2/localsub
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -2,3 +2,5 @@ spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver
 spring.datasource.url= jdbc:mysql://localhost/subway?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username= root
 spring.datasource.password= masterpw
+
+spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,6 +4,6 @@ spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=false
 
 spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver
-spring.datasource.url= jdbc:mysql://192.0.0.13/subway?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.url= jdbc:mysql://192.0.0.136/subway?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username= root
 spring.datasource.password= masterpw

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -7,3 +7,5 @@ spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver
 spring.datasource.url= jdbc:mysql://192.0.0.136/subway?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username= root
 spring.datasource.password= masterpw
+
+spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,9 @@
+logging.level.org.hibernate.type.descriptor.sql=info
+
+spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.properties.hibernate.format_sql=false
+
+spring.datasource.driver-class-name= com.mysql.cj.jdbc.Driver
+spring.datasource.url= jdbc:mysql://192.0.0.13/subway?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username= root
+spring.datasource.password= masterpw

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:localsub
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,3 +1,5 @@
+spring.flyway.enabled=false
+
 spring.datasource.url=jdbc:h2:mem:localsub
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.properties.hibernate.format_sql=true
 
 security.jwt.token.secret-key= eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno
 security.jwt.token.expire-length= 3600000
+
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=2

--- a/src/test/java/nextstep/subway/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/AcceptanceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
     @LocalServerPort


### PR DESCRIPTION
운영 데이터베이스를 추가할때 자동 public ip 를 할당받는 설정을 체크했는데, 이걸 없애지 못했습니다.
그리고 기존에 public ip 가 할당되지 않은 인스턴스에 eip  설정을 해도 public ip 가 할당되지 않는 문제가 있던데 어떤 점이 잘못 되었는지 알고 싶습니다.

마지막으로 원격으로 워크벤치나 datagrip으로 운영 db를 접속할 경우, db 인스턴스가 private 서브넷에 있을 때 방법이 있는지 궁금합니다.

---

## 운영 환경 구성하기

- [x]  웹 애플리케이션 앞단에 Reverse Proxy 구성하기
    - [x]  외부망에 Nginx로 Reverse Proxy를 구성
    - [x]  Reverse Proxy에 TLS 설정
- [x]  운영 데이터베이스 구성하기

## 개발 환경 구성하기

- [x]  설정 파일 나누기
    - JUnit : h2, Local : docker(mysql), Prod : 운영 DB를 사용하도록 설정
- [x]  데이터베이스 테이블 스키마 버전 관리