### PR TITLE
[1단계]- 서비스 구성하기 리뷰 요청드립니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,21 @@ npm run dev
 
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
-- 대역 : 
+- 대역
+  - 외부망1 : codingknowjam-externalA - 192.168.77.0/26
+  - 외부망2 : codingknowjam-externalB - 192.168.77.64/26
+  - 관리망  : codingknowjam-admin     - 192.168.77.128/27
+  - 내부망  : codingknowjam-internal  - 192.168.77.160/27
+
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
+- URL : http://52.78.64.56:8080/
+- DNS : coding-knowjam.kro.kr:8080/
 
 3. 베스천 서버에 접속을 위한 pem키는 [구글드라이브](https://drive.google.com/drive/folders/1dZiCUwNeH1LMglp8dyTqqsL1b2yBnzd1?usp=sharing)에 업로드해주세요
-
+ <br>
+ : 넵 업로드 했습니다.
 ---
 
 ### 2단계 - 배포하기


### PR DESCRIPTION
안녕하세요
AWS를 처음사용해보는 입장이여서 매우 많이 헤맸습니다 ㅠ
어찌저찌 설정을 완료하고 서비스 배포 및 DNS설정까지 완료했습니다.
진행하는 과정에서 한가지 궁금한 점이 있는데
AWS Security Group 설정에서 미션 요구사항에서는 외부망에 관리망 22번 포트를 열라고 되어있는데
관리망을 먼저 보안그룹을 생성하고 해당 관리망의 보안그룹 ID를 가져와서 셋팅을 할려고 하면 AWS내에서 계속 에러메세지를 뱉으면서 설정이 안되는데요 ㅠ
에러메세지는 다음과 같습니다.
"기존 IPv4 CIDR 규칙에 a 참조된 그룹 ID을(를) 지정할 수 없습니다."
제가 막 구글링해봤었는데 같은 가용영역?? 에 있어서 그런거 같다라는 말을 많이 본거같은데 정확한 이유가 뭔지는 잘 모르겠습니다.
좋은 피드백 부탁드립니다~
