### PR TITLE
feat: 1단계 망 분리하기 미션 README 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,19 @@ npm run dev
 
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
-- 대역 : 
+- 대역 :
+    - 10.0.0.0/26 - public-1
+    - 10.0.0.64/26 - public-2
+    - 10.0.0.128/27 - private-1 내부망
+    - 10.0.0.160/27 - bastion 관리망
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
+- URL : http://15.165.17.181:8080/
 
 3. 베스천 서버에 접속을 위한 pem키는 [구글드라이브](https://drive.google.com/drive/folders/1dZiCUwNeH1LMglp8dyTqqsL1b2yBnzd1?usp=sharing)에 업로드해주세요
+
+https://drive.google.com/file/d/1KIGG_1u9PE6hWcf8bSL74C7sTWy_i65O/view?usp=sharing
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm run dev
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : http://15.165.17.181:8080/
+- URL : http://3.36.135.254:8080/
 
 3. 베스천 서버에 접속을 위한 pem키는 [구글드라이브](https://drive.google.com/drive/folders/1dZiCUwNeH1LMglp8dyTqqsL1b2yBnzd1?usp=sharing)에 업로드해주세요
 


### PR DESCRIPTION
안녕하세요, 미션 제출드립니다.

미션 진행하면서 한가지 궁금한 점이 있어 질문과 함께 PR 날립니다 :)

 Q: 처음에 NAT Gateway를 설정할 때 서브넷을 인터넷이 필요한 내부망에 연결하고 삽질을 했는데, NAT Gateway를 연결할 때 서브넷을 Public Subnet에 연결하고 NAT Gateway가 연결된 Routing Table으로 내부망에 연결해 NAT을 사용하는 이유를 모르겠습니다! 그리고 NAT GateWay를 통상적으로(실무에서) 연결할 때, 이번 미션에서 진행한 방식과 같이  NAT Gateway를 설정하는지도 궁금합니다.