### PR TITLE
Step2 - 서비스 배포하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ npm run dev
 ---
 
 ### 2단계 - 배포하기
+#### 운영 환경 구성하기
+- [ ] 웹 애플리케이션 앞단에 Reverse Proxy 구성하기
+  - [ ] 외부망에 Nginx로 Reverse Proxy를 구성
+  - [ ] Reverse Proxy에 TLS 설정
+- [ ] 운영 데이터베이스 구성하기
+#### 개발 환경 구성하기
+- [ ] 설정 파일 나누기
+  - JUnit : h2
+  - Local : docker(mysql)
+  - Prod : 운영 DB를 사용하도록 설정
+---
 1. TLS가 적용된 URL을 알려주세요
 
 - URL : 

--- a/README.md
+++ b/README.md
@@ -98,19 +98,19 @@ npm run dev
 
 ### 2단계 - 배포하기
 #### 운영 환경 구성하기
-- [ ] 웹 애플리케이션 앞단에 Reverse Proxy 구성하기
-  - [ ] 외부망에 Nginx로 Reverse Proxy를 구성
-  - [ ] Reverse Proxy에 TLS 설정
-- [ ] 운영 데이터베이스 구성하기
+- [X] 웹 애플리케이션 앞단에 Reverse Proxy 구성하기
+  - [X] 외부망에 Nginx로 Reverse Proxy를 구성
+  - [X] Reverse Proxy에 TLS 설정
+- [X] 운영 데이터베이스 구성하기
 #### 개발 환경 구성하기
-- [ ] 설정 파일 나누기
+- [X] 설정 파일 나누기
   - JUnit : h2
   - Local : docker(mysql)
   - Prod : 운영 DB를 사용하도록 설정
 ---
 1. TLS가 적용된 URL을 알려주세요
 
-- URL : 
+- URL : yulmucha.r-e.kr
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'mysql:mysql-connector-java'
 }
 
 test {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,5 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/subway?useSSL=false
+spring.datasource.username=root
+spring.datasource.password=masterpw
+spring.jpa.hibernate.ddl-auto=create

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,5 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://192.168.104.135:3306/subway?useSSL=false
+spring.datasource.username=root
+spring.datasource.password=masterpw
+spring.jpa.hibernate.ddl-auto=none

--- a/src/test/java/nextstep/subway/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/AcceptanceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
     @LocalServerPort


### PR DESCRIPTION
안녕하세요. 리뷰 요청 드립니다.

테스트가 사용하는 application.properties(이 경우 `application-test.properties`)가 비어 있으면 테스트 시 자동으로 h2를 사용해서 그냥 비워 뒀습니다. 이것도 명시적으로 작성하는 게 좋은지 모르겠네요.
환경에 따라 나누어 놔도 `application.properties`는 공통으로 사용하는 것 같네요. JPA 로그 설정 같은 건 중복으로 넣어 줄 필요가 없겠군요.

감사합니다.