### PR TITLE
1단계 - 서비스 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run dev
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : http://woody-log.kro.kr:8080/
+- URL : http://woody-log.kro.kr
 
 
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,19 @@ npm run dev
 1. 서버에 접속을 위한 pem키를 [구글드라이브](https://drive.google.com/drive/folders/1dZiCUwNeH1LMglp8dyTqqsL1b2yBnzd1?usp=sharing)에 업로드해주세요
 
 2. 업로드한 pem키는 무엇인가요.
+- KEY-woody-log.pem
 
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
 - 대역 : 
+  - 192.168.125.0/26, 
+  - 192.168.125.64/26, 
+  - 192.168.125.128/27, 
+  - 192.168.125.160/27
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
+- URL : http://woody-log.kro.kr:8080/
 
 
 


### PR DESCRIPTION
안녕하세요. 리뷰어님 😄

잘 해결되지 않는 부분이 있어 질문 같이 남깁니다.

80 -> 8080 포트포워딩 하고자하여 아래와 같이 진행하였는데 잘 진행이 안되더라구요
- sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080 (포트포워딩)
- woody-log2-public-SG 에서 80 포트 허용 (보안그룹 설정)

http://woody-log.kro.kr 로 접속 가능하도록 하고 싶은데 잘 안되는것 같아요.. 혹시 추가적으로 설정해야하는 부분이 있을까요?