### PR TITLE
🚀 2단계 - 배포하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run dev
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : https://sanhee.kro.kr:8080/
+- URL : https://sanoeul.kro.kr/
 
 
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run dev
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : http://infra.sanhee.kro.kr:8080/
+- URL : https://sanhee.kro.kr:8080/
 
 
 
@@ -67,7 +67,17 @@ npm run dev
 ### 2단계 - 배포하기
 1. TLS가 적용된 URL을 알려주세요
 
-- URL : 
+- URL : https://sanoeul.kro.kr/
+
+**운영 환경 구성하기**
+- [X] 웹 애플리케이션 앞단에 Reverse Proxy 구성하기
+    - [X] 외부망에 Nginx로 Reverse Proxy를 구성
+    - [X] Reverse Proxy에 TLS 설정
+- [X] 운영 데이터베이스 구성하기
+
+**개발 환경 구성하기**
+- [X] 설정 파일 나누기
+- [X] JUnit : h2, Local : docker(mysql), Prod : 운영 DB를 사용하도록 설정
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	runtimeOnly 'com.h2database:h2'
+	implementation 'mysql:mysql-connector-java'
 }
 
 test {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,9 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.datasource.url=jdbc:mysql://localhost:3306/subway?autoReconnect=true
+spring.datasource.username=root
+spring.datasource.password=masterpw
+logging.level.org.hibernate.type.descriptor.sql=trace
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,5 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.datasource.url=jdbc:mysql://192.192.192.149:3306/subway?autoReconnect=true
+spring.datasource.username=root
+spring.datasource.password=masterpw

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,4 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:test
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/test/java/nextstep/subway/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/AcceptanceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
     @LocalServerPort


### PR DESCRIPTION
안녕하세요, 리뷰어님!
[NAT gateway는 외부망에 구성해야 한다는 피드백](https://github.com/next-step/infra-subway-deploy/pull/644#discussion_r903897977) 반영 완료했습니다.
놓쳤던 부분인데 짚어주셔서 감사합니다 :)

그리고 2단계 추가 미션을 제외하고 모두 완료하여, 리뷰 요청 드립니다.
리뷰 해주셔서 감사합니다. 😁

## 질문

- TLS 인증서를 발급 받지 않은 원래 주소 (http://43.200.26.109:8080/) 의 경우 
   - 서비스의 8080 포트로 접근이 가능한 것을 확인했습니다.
- **TLS 인증서를 발급 받은 주소** (https://sanoeul.kro.kr:8080/) 의 경우
   - **8080 포트로 접근 시** `사이트에 보안 연결할 수 없음` 메시지가 나오면서 **접근이 차단**되는 데 어느 곳에서 해당 로직을 처리해주는지 궁금해서 질문 드립니다!..
      - `nginx.config`는 [강의 자료](https://edu.nextstep.camp/s/mm53Ke6y/ls/rZnYJwZL#:~:text=%F0%9F%93%8C-,nginx.conf,-%ED%8C%8C%EC%9D%BC%EC%9D%84%20%EC%95%84%EB%9E%98%EC%99%80%20%EA%B0%99%EC%9D%B4)를 참고해서 사용하였습니다.
     - https://sanoeul.kro.kr/ 는 정상 동작 합니다.