### PR TITLE
[Step1] 망 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,21 @@ npm run dev
 
 2. 업로드한 pem키는 무엇인가요. : `mand2-nextstep-infra-key.pem`
 
+---
+
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
 - 대역 : 
-
+    - [x]  외부망으로 사용할 Subnet : 64개씩 2개 (AZ를 다르게 구성)
+        - `mand2-public-subnet-a` 192.168.14.0/26
+        - `mand2-public-subnet-c` 192.168.14.64/26
+    - [x]  내부망으로 사용할 Subnet : 32개씩 1개
+        - `mand2-private-subnet-a` 192.168.14.128/27
+    - [x]  관리용으로 사용할 Subnet : 32개씩 1개
+        - `mand2-bastion-subnet-c` 192.168.14.160/27
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
+- URL : [`mand2-infra-subway`](http://www.mand2-infra-subway.kro.kr:8080/)
 
 
 


### PR DESCRIPTION
안녕하세요 😀 
Step1 PR 요청드립니다 

질문1  
Security Group 설정할 때, 내부망 설정 중에 **외부망 3306 포트 오픈**이라고 되어있는데요,
소스를 [외부망용 SG]로, 3306 포트로 세팅하라는 뜻으로 이해한게 맞을까요? 🤔

다른 분들이 어떻게 설정했는지 봤는데 조금씩 다르더라구요!! 
- 저처럼 외부망 security group id 로 직접 연결는 분(i.e. sg-0d98a89ecb28628c0),
- 외부망용 subnet 두개를 각각 설정해줘서 연결하는 분 (i.e. 192.168.14.0/26, 192.168.14.64/26 두 개로 연결)

두 방식 모두 같은 바를 뜻하긴 하지만, 관리 이슈 때문에 security group id로 연결하라는 뜻인가 싶어서요. 
궁금하여 질문 남깁니다. 감사합니다~ 🙇‍♀️

---
### TODO List
- [x]  VPC 생성
    - CIDR은 C class(x.x.x.x/24)로 생성. 이 때, 다른 사람과 겹치지 않게 생성
    - 192.168.14.0/24 `vpc-03484a260d899b8c5 | mand2-vpc`
- [x]  Subnet 생성
    - [x]  외부망으로 사용할 Subnet : 64개씩 2개 (AZ를 다르게 구성)
        - `mand2-public-subnet-a` 192.168.14.0/26 
        - `mand2-public-subnet-c` 192.168.14.64/26
    - [x]  내부망으로 사용할 Subnet : 32개씩 1개
        - `mand2-private-subnet-a` 192.168.14.128/27 
    - [x]  관리용으로 사용할 Subnet : 32개씩 1개
        - `mand2-bastion-subnet-c` 192.168.14.160/27
- [x]  Internet Gateway 연결
    - `mand2-igw` igw-0df5175c63c094c50 , mand2-vpc와 연결완료 
- [x]  Route Table 생성
    - public : `mand2-public-rt` rtb-0c191fd9d60edcf60
    - private : `mand2-private-rt` rtb-0b40d310fc5c4df12
    - bastion : `mand2-bastion-rt` rtb-057845261e4553a24
- [x]  Security Group 설정
    - [x]  외부망 `SG-mand2-public` sg-0d98a89ecb28628c0
        - 전체 대역 : 8080 포트 오픈
        - 관리망 : 22번 포트 오픈
    - [x]  내부망 `SG-mand2-private` sg-0ba6d11af1db2b291
        - 외부망 : 3306 포트 오픈
        - 관리망 : 22번 포트 오픈
    - [x]  관리망 `SG-mand2-bastion` sg-0c540df259df589ac
        - 자신의 공인 IP : 22번 포트 오픈
- [x]  서버 생성
    - [x]  외부망에 웹 서비스용도의 EC2 생성
    - [x]  내부망에 데이터베이스용도의 EC2 생성
    - [x]  관리망에 베스쳔 서버용도의 EC2 생성
    - [x]  베스쳔 서버에 Session Timeout 600s 설정
    - [x]  베스쳔 서버에 Command 감사로그 설정

**웹 애플리케이션 배포**

- [x]  외부망에 [웹 애플리케이션](https://github.com/next-step/infra-subway-deploy)을 배포
- [x]  DNS 설정 : [`mand2-infra-subway`](http://www.mand2-infra-subway.kro.kr:8080/)
