### PR TITLE
1단계 - 망 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ npm run dev
 ### 1단계 - 망 구성하기
 1. 구성한 망의 서브넷 대역을 알려주세요
 - 대역 : 
+  - (외부망-1) cohys7-subnet-public-a : 192.168.10.0/26
+  - (외부망-2) cohys7-subnet-public-b : 192.168.10.64/26
+  - (내부망) cohys7-subnet-private : 192.168.10.128/27
+  - (관리망) cohys7-subnet-manage : 192.168.10.160/27
 
 2. 배포한 서비스의 공인 IP(혹은 URL)를 알려주세요
 
-- URL : 
-
-
+- URL : http://www.cohys7-runningmap.o-r.kr:8080/
 
 ---
 


### PR DESCRIPTION
안녕하세요! 1단계 PR 드립니다.
조금 늦었지만 남은 기간동안 완주를 목표로 진행해보려합니다 :)
하면서 궁금했던 점도 질문드립니다! 확인 부탁드립니다!
감사합니다~

Q1. 망구성하기 내용 중에서 Bastion Server에 공개키를 생성하고, 접속하려는 서버에 키를 추가하는 부분이 있는데
EC2에서 인스턴스 생성시 이용한 pem키를 사용하면 사용하지 않아도 되는 부분인 것 같은데 따로 사용되는 곳이 있는 것인가요?
```
## Bastion Server에서 공개키를 생성합니다.
bastion $ ssh-keygen -t rsa
bastion $ cat ~/.ssh/id_rsa.pub

## 접속하려는 서비스용 서버에 키를 추가합니다.
$ vi ~/.ssh/authorized_keys
```

Q2. 도메인 연결을 진행하면서 8080 포트를 명시하지 않아도 되도록 사용하고 싶은데,
포트포워딩으로 80포트로 들어온 요청을 8080으로 연결하도록 설정해도 안됩니다...
```
$ sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
```
설정 미스인지 다른 방법이 있는 것인지 궁금합니다..!